### PR TITLE
Update FertileFields Patch

### DIFF
--- a/1.1/Patches/Fertile Fields/Patch_Balance.xml
+++ b/1.1/Patches/Fertile Fields/Patch_Balance.xml
@@ -2,71 +2,89 @@
 <Patch>
 
 	<Operation Class="PatchOperationFindMod">
-					<mods>
-						<li>Fertile Fields [1.1]</li>								
-					</mods>
+		<mods>
+			<li>Fertile Fields [1.1]</li>
+		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
 
-		<!-- Because Fertile Fields uses relatively small quanties of teraforming resources, some stuff has to be adjusted. -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_FiberFromWood"]/products/N7_PlantFiber</xpath>
-				<value>
-					<N7_PlantFiber>20</N7_PlantFiber>
-				</value>
-			</li>
+				<!-- Because Fertile Fields uses relatively small quanties of teraforming resources, some stuff has to be adjusted. -->
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="MineableClay"]/building/mineableYield</xpath>
-				<value>
-					<mineableYield>5</mineableYield>
-				</value>
-			</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Make_FiberFromWood"]/products/N7_PlantFiber</xpath>
+					<value>
+						<N7_PlantFiber>20</N7_PlantFiber>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_RawMudbricks"]/ingredients/li[1]/count</xpath>
-				<value>
-					<count>5</count>
-				</value>
-			</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="MineableClay"]/building/mineableYield</xpath>
+					<value>
+						<mineableYield>5</mineableYield>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_RawMudbricks"]/ingredients/li[2]/count</xpath>
-				<value>
-					<count>5</count>
-				</value>
-			</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Make_RawMudbricks"]/ingredients/li[1]/count</xpath>
+					<value>
+						<count>5</count>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Make_RawMudbricks"]/ingredients/li[2]/count</xpath>
+					<value>
+						<count>5</count>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_RawBricks"]/ingredients/li[1]/count</xpath>
-				<value>
-					<count>5</count>
-				</value>
-			</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Make_RawBricks"]/ingredients/li[1]/count</xpath>
+					<value>
+						<count>5</count>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Make_RawBricks"]/ingredients/li[2]/count</xpath>
+					<value>
+						<count>5</count>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_RawBricks"]/ingredients/li[2]/count</xpath>
-				<value>
-					<count>5</count>
-				</value>
-			</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Make_HardenedCeramic"]/ingredients/li[1]/count</xpath>
+					<value>
+						<count>2</count>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Make_HardenedCeramic"]/ingredients/li[2]/count</xpath>
+					<value>
+						<count>3</count>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_Porcelain"]/ingredients/li[1]/count</xpath>
-				<value>
-					<count>5</count>
-				</value>
-			</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Make_Wafer"]/ingredients/li[2]/count</xpath>
+					<value>
+						<count>5</count>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_Porcelain"]/ingredients/li[2]/count</xpath>
-				<value>
-					<count>5</count>
-				</value>
-			</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Make_Porcelain"]/ingredients/li[1]/count</xpath>
+					<value>
+						<count>6</count>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Make_Porcelain"]/ingredients/li[2]/count</xpath>
+					<value>
+						<count>2</count>
+					</value>
+				</li>
 
-			</operations>		
+			</operations>
 		</match>
 	</Operation>
-	
+
 </Patch>

--- a/1.1/Patches/Fertile Fields/Patch_Ceramics.xml
+++ b/1.1/Patches/Fertile Fields/Patch_Ceramics.xml
@@ -2,112 +2,65 @@
 <Patch>
 
 	<Operation Class="PatchOperationFindMod">
-					<mods>
-						<li>Fertile Fields [1.1]</li>								
-					</mods>
+		<mods>
+			<li>Fertile Fields [1.1]</li>
+		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-			
-			<!-- Allow plant scraps to be used to make mudbricks -->			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="PlantScraps"]/thingCategories</xpath>
-				<value>
-					<li>PlantMatter</li>
-				</value>
-			</li>
-			
-			<!-- Replace Ceramics' sand with Fertile Fields' -->			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_RawBricks"]/ingredients/li[2]/filter/thingDefs</xpath>
-				<value>
-					<thingDefs>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PlantScraps"]/thingCategories</xpath>
+					<value>
+						<li>PlantMatter</li>
+					</value>
+				</li>
+
+				<!-- Replace Ceramics' sand with Fertile Fields' -->
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="N7_Sand"]</xpath>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[
+						defName="Make_RawBricks" or
+						defName="Make_HardenedCeramic" or
+						defName="Make_Wafer" or
+						defName="Make_Porcelain" or
+						defName="Make_RawBricks" or
+						defName="Make_HardenedCeramic" or
+						defName="Make_Wafer" or
+						defName="Make_Porcelain"
+						]//thingDefs[li="N7_Sand"]/li</xpath>
+					<value>
 						<li>SandPile</li>
-					</thingDefs>
-				</value>
-			</li>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_HardenedCeramic"]/ingredients/li[2]/filter/thingDefs</xpath>
-				<value>
-					<thingDefs>
-						<li>SandPile</li>
-					</thingDefs>
-				</value>
-			</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Collect50Sand"]/*[self::label or self::description]/text()</xpath>
+					<value>Collect sand</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Collect50Sand"]/products/N7_Sand</xpath>
+					<value>
+						<SandPile>2</SandPile>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_Wafer"]/ingredients/li[2]/filter/thingDefs</xpath>
-				<value>
-					<thingDefs>
-						<li>SandPile</li>
-					</thingDefs>
-				</value>
-			</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Collect25Clay"]/*[self::label or self::description]/text()</xpath>
+					<value>Collect clay</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="Collect25Clay"]/products/N7_RawClay</xpath>
+					<value>
+						<N7_RawClay>1</N7_RawClay>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_Porcelain"]/ingredients/li[1]/filter/thingDefs</xpath>
-				<value>
-					<thingDefs>
-						<li>SandPile</li>
-					</thingDefs>
-				</value>
-			</li>
+			</operations>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_RawBricks"]/fixedIngredientFilter/thingDefs/li[1]</xpath>
-				<value>
-					<li>SandPile</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_HardenedCeramic"]/fixedIngredientFilter/thingDefs/li[1]</xpath>
-				<value>
-					<li>SandPile</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_Wafer"]/fixedIngredientFilter/thingDefs/li[1]</xpath>
-				<value>
-					<li>SandPile</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="Make_Porcelain"]/fixedIngredientFilter/thingDefs/li[1]</xpath>
-				<value>
-					<li>SandPile</li>
-				</value>
-			</li>
-
-			<!-- Remove Ceramics Content: Clay Pit, Clay Spot, Sand, Recipes -->
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/RecipeDef[defName="Collect50Sand"]</xpath>
-			</li>
-
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/RecipeDef[defName="Collect25Clay"]</xpath>
-			</li>
-
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/WorkGiverDef[defName="DoBillsCollectClay"]</xpath>
-			</li>
-			
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="ClayPit"]</xpath>
-			</li>
-
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="ClayGatheringSpot"]</xpath>
-			</li>
-
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="N7_Sand"]</xpath>
-			</li>
-
-			</operations>		
 		</match>
 	</Operation>
-	
+
 </Patch>

--- a/1.1/Patches/Fertile Fields/Patch_FertileFields.xml
+++ b/1.1/Patches/Fertile Fields/Patch_FertileFields.xml
@@ -2,275 +2,156 @@
 <Patch>
 
 	<Operation Class="PatchOperationFindMod">
-					<mods>
-						<li>Fertile Fields [1.1]</li>						
-					</mods>
+		<mods>
+			<li>Fertile Fields [1.1]</li>
+		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
 
-			<!-- Replace Fertile Fields' textures for sand with Ceramics' -->			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="SandPile"]/graphicData/texPath</xpath>
-				<value>
-					<texPath>Things/Item/Sand</texPath>
-				</value>
-			</li>
+				<!-- Replace Fertile Fields' textures for sand with Ceramics' -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="SandPile"]/graphicData/texPath</xpath>
+					<value>
+						<texPath>Things/Item/Sand</texPath>
+					</value>
+				</li>
 
-			<!-- Replace Fertile Fields' brick wall recipe -->			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="BrickWall"]/costList/RFFBricks</xpath>
-				<value>
-					<N7_FiredBrick>4</N7_FiredBrick>
-				</value>
-			</li>
+				<!-- Remove Fertile Fields Content: PFFBricks, BrickWall, Clay -->
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[
+						defName="RFFClay" or
+						defName="RFFBricks"
+						]</xpath>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/RecipeDef[
+						defName="MakeBricks" or
+						defName="MakeFastBricks"
+						]</xpath>
+				</li>
 
-            <!-- Remove Fertile Fields Content: PFFBricks, BrickWall, Clay -->
-		
-            <li Class="PatchOperationRemove">
-                <xpath>Defs/ThingDef[defName="RFFBricks"]</xpath>
-            </li>
+				<!-- Hide Brickwall -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BrickWall"]</xpath>
+					<value>
+						<ThingDef>
+							<defName>BrickWall</defName>
+							<label>BrickWall-dummy</label>
+							<thingClass>Building</thingClass>
+						</ThingDef>
+					</value>
+				</li>
 
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="RFFClay"]</xpath>
-			</li>
+				<!-- Replace RFFClay with N7_Clay -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="Terraform_Gravel-RockyDirt" or
+						defName="Terraform_Gravel-Sand" or
+						defName="Terraform_SoilF-Sand"
+						]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
+					<value>
+						<N7_RawClay>1</N7_RawClay>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="Terraform_RockyDirt-Gravel" or
+						defName="Terraform_Sand-Gravel" or
+						defName="Terraform_Sand-SoilF"
+						]/costList/RFFClay</xpath>
+					<value>
+						<N7_RawClay>1</N7_RawClay>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="Terraform_SoilF-Marsh" or
+						defName="Terraform_Mud-Marsh" or
+						defName="Terraform_SoilMarshy-Marsh" or
+						defName="Terraform_Sand-WaterShallow" or
+						defName="Terraform_SoilF-WaterShallow" or
+						defName="Terraform_RockyDirt-WaterShallow" or
+						defName="Terraform_WaterShallow-WaterDeep" or
+						defName="Terraform_Marsh-WaterDeep"
+						]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
+					<value>
+						<N7_RawClay>5</N7_RawClay>
+					</value>
+				</li>
 
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/RecipeDef[defName="MakeBricks"]</xpath>
-			</li>
+				<!-- Replace products in recipes -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="SplitDirt"]/products/RFFClay</xpath>
+					<value>
+						<N7_RawClay>1</N7_RawClay>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="SplitDirtBulk"]/products/RFFClay</xpath>
+					<value>
+						<N7_RawClay>5</N7_RawClay>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="DirtToClay"]/products/RFFClay</xpath>
+					<value>
+						<N7_RawClay>2</N7_RawClay>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="DirtToClayBulk"]/products/RFFClay</xpath>
+					<value>
+						<N7_RawClay>10</N7_RawClay>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="MakeClay"]/products/RFFClay</xpath>
+					<value>
+						<N7_RawClay>1</N7_RawClay>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[defName="MakeClayBulk"]/products/RFFClay</xpath>
+					<value>
+						<N7_RawClay>5</N7_RawClay>
+					</value>
+				</li>
 
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/RecipeDef[defName="MakeFastBricks"]</xpath>
-			</li>
-
-			<!-- Replace RFFClay with N7_Clay -->
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_Gravel-RockyDirt"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>1</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_Gravel-Sand"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>1</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_SoilF-Sand"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>1</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_RockyDirt-Gravel"]/costList/RFFClay</xpath>
-				<value>
-					<N7_RawClay>1</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_Sand-Gravel"]/costList/RFFClay</xpath>
-				<value>
-					<N7_RawClay>1</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_Sand-SoilF"]/costList/RFFClay</xpath>
-				<value>
-					<N7_RawClay>1</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="SplitDirt"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>1</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="SplitDirtBulk"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>5</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="DirtToClay"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>2</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="DirtToClayBulk"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>2</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="MakeClay"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>1</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="MakeClayBulk"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>5</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_SoilF-Marsh"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>5</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_Mud-Marsh"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>5</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_SoilMarshy-Marsh"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>5</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_Sand-WaterShallow"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>5</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_SoilF-WaterShallow"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>5</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_RockyDirt-WaterShallow"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>5</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_WaterShallow-WaterDeep"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>5</N7_RawClay>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Terraform_Marsh-WaterDeep"]/modExtensions/li[@Class="RFF_Code.Terraformer"]/products/RFFClay</xpath>
-				<value>
-					<N7_RawClay>5</N7_RawClay>
-				</value>
-			</li>
-
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="MakeDirt"]/ingredients/li[1]/filter/thingDefs/li</xpath>
-				<value>
-					<li>N7_RawClay</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="MakeDirt"]/fixedIngredientFilter/thingDefs/li[1]</xpath>
-				<value>
-					<li>N7_RawClay</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="MakeDirtBulk"]/ingredients/li[1]/filter/thingDefs</xpath>
-				<value>
-					<thingDefs>
+				<!-- Replace ingredients -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/RecipeDef[
+						defName="MakeDirt" or
+						defName="MakeDirtBulk"
+						]//thingDefs[li="RFFClay"]/li</xpath>
+					<value>
 						<li>N7_RawClay</li>
-					</thingDefs>
-				</value>
-			</li>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="MakeDirtBulk"]/fixedIngredientFilter/thingDefs/li[1]</xpath>
-				<value>
-					<li>N7_RawClay</li>
-				</value>
-			</li>
-	
-<!--
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="MakeDirtEfficient"]/ingredients/li[1]/filter/thingDefs</xpath>
-				<value>
-					<thingDefs>
-						<li>N7_RawClay</li>
-					</thingDefs>
-				</value>
-			</li>
+				<!-- Replace RFFBrick with N7_FiredBrick -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/TerrainDef[defName="HBBrickFloor"]/costList/RFFBricks</xpath>
+					<value>
+						<N7_FiredBrick>4</N7_FiredBrick>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="MakeDirtEfficient"]/fixedIngredientFilter/thingDefs/li[1]</xpath>
-				<value>
-					<li>N7_RawClay</li>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="MakeDirt5Efficient"]/ingredients/li[1]/filter/thingDefs</xpath>
-				<value>
-					<thingDefs>
-						<li>N7_RawClay</li>
-					</thingDefs>
-				</value>
-			</li>
+				<!-- Remove Fertile Fields Brick Floor -->
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/TerrainDef[defName="BrickFloor"]</xpath>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/RecipeDef[defName="MakeDirt5Efficient"]/fixedIngredientFilter/thingDefs/li[1]</xpath>
-				<value>
-					<li>N7_RawClay</li>
-				</value>
-			</li>
--->
-			<!-- Replace RFFBrick with N7_FiredBrick -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/TerrainDef[defName="HBBrickFloor"]/costList/RFFBricks</xpath>
-				<value>
-					<N7_FiredBrick>4</N7_FiredBrick>
-				</value>
-			</li>
-
-			<!-- Remove Fertile Fields Brick Floor -->
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/TerrainDef[defName="BrickFloor"]</xpath>
-			</li>
-
-			<!-- Adjust Research Tab Placement -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ResearchProjectDef[defName="RFF_Farming"]/researchViewY</xpath>
+				<!-- Adjust Research Tab Placement -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ResearchProjectDef[defName="RFF_Farming"]/researchViewY</xpath>
 					<value>
 						<researchViewY>4.5</researchViewY>
 					</value>
-			</li>
-	
-			</operations>		
+				</li>
+
+			</operations>
+
 		</match>
 	</Operation>
-	
+
 </Patch>


### PR DESCRIPTION
This patch targets 1.1 and 1.2 Fertile Fields.

* Optimizes the patch operations to fewer ones. 
* Balances the missed recipes:
  - Make_HardenedCeramic
  - Make_Wafer
* Replace FF Brickwall with a dummy to prevent red errors.
* Keeps the clay gathering spot and the clay pit but gives it balanced recipes with the right name and description.